### PR TITLE
feat: add agent API routes

### DIFF
--- a/agent/package-lock.json
+++ b/agent/package-lock.json
@@ -1,0 +1,138 @@
+{
+  "name": "shade-agent",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shade-agent",
+      "version": "0.1.0",
+      "dependencies": {
+        "@neardefi/shade-agent-js": "^1.0.4",
+        "ethers": "^6.6.0",
+        "zod": "^3.22.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@neardefi/shade-agent-js": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@neardefi/shade-agent-js/-/shade-agent-js-1.0.4.tgz",
+      "integrity": "sha512-bFbthz4DV54YCGFMCf8hX9w7lco5HQ9FY662VWBIU8Sc8FDOvsBRLD3rS07cVI7j5tkVclT8h12nOZF1isz4Eg==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/ethers": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
+      "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/agent/package.json
+++ b/agent/package.json
@@ -5,6 +5,7 @@
     "test": "echo 'No tests specified'"
   },
   "dependencies": {
+    "@neardefi/shade-agent-js": "^1.0.4",
     "ethers": "^6.6.0",
     "zod": "^3.22.0"
   }

--- a/agent/pages/api/agent-account.ts
+++ b/agent/pages/api/agent-account.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { agentAccountId } from '@neardefi/shade-agent-js';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.status(405).end();
+    return;
+  }
+
+  try {
+    const account = await agentAccountId();
+    res.status(200).json(account);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/agent/pages/api/eth-account.ts
+++ b/agent/pages/api/eth-account.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { agent } from '@neardefi/shade-agent-js';
+import { ethers } from 'ethers';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.status(405).end();
+    return;
+  }
+
+  try {
+    // TODO: confirm the correct agent method for fetching the EVM public key
+    const { public_key } = await agent('evm_public_key');
+    const address = ethers.computeAddress('0x' + public_key);
+    res.status(200).json({ address });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/agent/src/core/signAndSend.ts
+++ b/agent/src/core/signAndSend.ts
@@ -1,6 +1,11 @@
-// Placeholder for requestSignature integration and broadcasting
+import { requestSignature } from '@neardefi/shade-agent-js';
+
 export async function signAndSend(tx: Uint8Array): Promise<string> {
-  // TODO: integrate with Shade Agent contract
-  // and broadcast to the target chain
+  // Request the agent to sign the transaction payload.
+  const payload = Buffer.from(tx).toString('hex');
+  await requestSignature({ path: 'm/0', payload });
+
+  // TODO: use the returned signature to broadcast the transaction
+  // and return the resulting transaction hash.
   return 'txHashPlaceholder';
 }


### PR DESCRIPTION
## Summary
- add endpoints for agent and EVM accounts
- integrate shade-agent-js requestSignature stub
- include shade-agent-js package

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba4b92acd08325bf9e392a0a0dec59